### PR TITLE
Added UTF-8 BOM protection to config loader

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -84,7 +84,13 @@ function merge() {
 
 function getConfig(file) {
     try {
-        return yml.safeLoad(fs.readFileSync(file));
+        //Protect against stupid Windows programs being stupid and putting
+        //stupid UTF-8 BOM marks at the stupid beginning of the stupid file
+        var contents = fs.readFileSync(file);
+        if (contents.length >= 3 && contents[0] === 0xef && contents[1] === 0xbb && contents[2] === 0xbf) {
+            contents = contents.slice(3);
+        }
+        return yml.safeLoad(contents);
     } catch (e) {
         console.warn('Configuration file (`' + file + '`) not found: ' + e);
         return {};


### PR DESCRIPTION
Will be useful for anyone editing config files on Windows, where programs just *love* to add UTF-8 BOMs to *every* text file *ever*