### PR TITLE
Fixing binge likes

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -84,7 +84,13 @@ function merge() {
 
 function getConfig(file) {
     try {
-        return yml.safeLoad(fs.readFileSync(file));
+        //Protect against stupid Windows programs being stupid and putting
+        //stupid UTF-8 BOM marks at the stupid beginning of the stupid file
+        var contents = fs.readFileSync(file);
+        if (contents.length >= 3 && contents[0] === 0xef && contents[1] === 0xbb && contents[2] === 0xbf) {
+            contents = contents.slice(3);
+        }
+        return yml.safeLoad(contents);
     } catch (e) {
         console.warn('Configuration file (`' + file + '`) not found: ' + e);
         return {};

--- a/sock_modules/likes.js
+++ b/sock_modules/likes.js
@@ -40,7 +40,7 @@ function binge(callback) {
 
 function innerBinge(topic, callback) {
     var msg = 'Liking /t/%TOPIC%/%POST% by @%USER%';
-    discourse.getAllPosts(topic, function (posts, next) {
+    discourse.getAllPosts(topic, function (err, posts, next) {
         var likeables = posts.filter(function (x) {
             var action = x.actions_summary.filter(function (y) {
                 return y.id === 2;


### PR DESCRIPTION
Not sure how this one escaped for so long, but the callback the likes binge passed to getAllPosts should have had three parameters, not two; the posts collection was coming through as NULL, and hard-crashing the bot