### PR TITLE
Fixed command parsing to handle multiple spaces between args

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 test.js
+sock_modules/eliza/**

--- a/commands.js
+++ b/commands.js
@@ -5,7 +5,7 @@ var regexp = require('xregexp').XRegExp,
 var discourse,
     spaces = '[ \f\r\t\v\u00a0\u1680\u180e\u2000-\u200a' +
     '\u2028\u2029\u202f\u205f\u3000]+',
-    parser = regexp('^!(?<mod>\\w+)' + spaces + '+(?<cmd>\\S+)(?<args>(' +
+    parser = regexp('^!(?<mod>\\w+)' + spaces + '(?<cmd>\\S+)(?<args>(' +
         spaces + '\\S+)+)?\\s*$', 'mn'),
     splitter = regexp(spaces),
     sockModules = {};

--- a/commands.js
+++ b/commands.js
@@ -4,10 +4,10 @@ var regexp = require('xregexp').XRegExp,
 
 var discourse,
     spaces = '[ \f\r\t\v\u00a0\u1680\u180e\u2000-\u200a' +
-    '\u2028\u2029\u202f\u205f\u3000]',
+    '\u2028\u2029\u202f\u205f\u3000]+',
     parser = regexp('^!(?<mod>\\w+)' + spaces + '+(?<cmd>\\S+)(?<args>(' +
         spaces + '\\S+)+)?\\s*$', 'mn'),
-    splitter = regexp(spaces + '+'),
+    splitter = regexp(spaces),
     sockModules = {};
 
 exports.description = 'The Command Parser Module';


### PR DESCRIPTION
Also added tar's ported eliza code to the eslint ignore list; it produced a *lot* of errors…