### PR TITLE
Better handling of queries with no set defaults

### DIFF
--- a/sock_modules/stats.yml
+++ b/sock_modules/stats.yml
@@ -110,8 +110,6 @@
     FROM QUERY
   config:
     trust_level: 1
-    defaults:
-      1: []
   name: MonthPosts
   chart:
     filename: MonthPosts %date%
@@ -273,8 +271,6 @@
 - query: 
   config:
     trust_level: 1
-    defaults:
-      1: ['']
   name: trust
 - query: |
     WITH badge_counts AS (

--- a/sock_modules/statsporn.js
+++ b/sock_modules/statsporn.js
@@ -239,7 +239,7 @@ function checkCooldown(topic) {
 }
 
 exports.onNotify = function (type, notification, topic, post, callback) {
-    if (['private_message', 'mentioned', 'replied'].indexOf(type) < 0) {
+    if (['private_message', 'mentioned'].indexOf(type) < 0) {
         return callback();
     }
     var cmd = parseCmd(post);

--- a/sock_modules/statsporn.js
+++ b/sock_modules/statsporn.js
@@ -42,10 +42,12 @@ function parseArgs(parts, query, post) {
     if (parts.args) {
         parts.args = parts.args.trim().split(' ');
     }
-    for (; trust >= 0; trust -= 1) {
-        if (query.config.defaults[trust]) {
-            defaults = query.config.defaults[trust].slice();
-            break;
+    if (query.config.defaults) {
+        for (; trust >= 0; trust -= 1) {
+            if (query.config.defaults[trust]) {
+                defaults = query.config.defaults[trust].slice();
+                break;
+            }
         }
     }
     if (post.trust_level >= 4 && parts.args) {
@@ -266,14 +268,16 @@ function listQueries(notification, callback) {
     }
     var res = queries.map(function (q) {
         var args;
-        q.config.defaults = q.config.defaults || [];
-        for (var i = 0; i <= 10; i += 1) {
-            if (q.config.defaults[i]) {
-                args = '\'' + q.config.defaults[i].join('\' \'') + '\'';
-                break;
+        if (q.config.defaults) {
+            for (var i = 0; i <= 10; i += 1) {
+                if (q.config.defaults[i]) {
+                    args = '\'' + q.config.defaults[i].join('\' \'') + '\'';
+                    break;
+                }
             }
         }
-        return q.name + ' ' + args + ':\tAvailable to trust level ' +
+        var query = args ? q.name + ' ' + args : q.name;
+        return query + ':\tAvailable to trust level ' +
             q.config.trust_level + '+';
     });
     res.unshift('Available queries:');


### PR DESCRIPTION
Also means we don't need a `defaults` section in the YAML for queries that have none
Also should no longer show `undefined` as the args list

@AccaliaDeElementia, I'd like you to review this before merging, just in case I screwed up :wink: