### PR TITLE
Add argument testing to the DB restore script

### DIFF
--- a/admin_modules/backup.sh
+++ b/admin_modules/backup.sh
@@ -2,10 +2,18 @@
 
 
 restoreBackup() {
+    test -f "$1" || {
+        echo "usage: $0 <backup.sh>"
+        return 1
+    }
+    tar -tzf "$1" | grep 'dump.sql' >/dev/null || {
+        echo "archive not a compressed tar or does not contain dump.sql"
+        return 1
+    }
     echo 'RESTORE: Dropping Old `restore` Schema;'
     psql -q -d 'discourse' -c 'DROP SCHEMA backup CASCADE' || return 1;
     echo 'RESTORE: Loading to `restore` Schema'
-    tar -xOzf $1 'dump.sql' | psql -q -d 'discourse' || return 1
+    tar -xOzf "$1" 'dump.sql' | psql -q -d 'discourse' || return 1
     echo 'RESTORE: Renaming Old Schema to `backup`';
     psql -d 'discourse' -c 'ALTER SCHEMA public RENAME TO backup' || return 1
     echo 'RESTORE: Finalizing Restore';


### PR DESCRIPTION
Ensure that the database is not hit unless the tar archive exists and contains dump.sql; stops embarrassing mistakes!